### PR TITLE
Give an option to bypass mkdocs when the user doesn't want site generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Following configuration options are available:
 | `source_dir` |  No | Directory that contains the source files for site generation. Defaults to `docs` |
 | `iam_role_arn` |  No | ARN of the IAM role to assume. Used for S3 file sync |
 | `aws_region` |  No | AWS region name used by aws-cli commands |
+| `site_generation` |  No | `true` if you want to generate html files from markdown files, `false` if the source files are already html. Defaults to `true`  |
 
 Note that if you use an iam role to acquire credentials for S3, the drone agent EC2 role must have permission to assume the configured role.
 

--- a/plugin.sh
+++ b/plugin.sh
@@ -6,15 +6,23 @@ die() { echo "$1"; exit 1; }
 
 src_dir="${PLUGIN_SOURCE_DIR:-./}"
 iam_role="${PLUGIN_IAM_ROLE_ARN:-NONE}"
+site_generation="${PLUGIN_SITE_GENERATION:-true}" 
 
 [ -n "${PLUGIN_AWS_REGION}" ] && export AWS_REGION="${PLUGIN_AWS_REGION}" AWS_DEFAULT_REGION="${PLUGIN_AWS_REGION}"
 
 [ -z "${PLUGIN_BUCKET}" ] && die "bucket name is not set"
 [ -z "${PLUGIN_SITE_PATH}" ] && die "site path is not set"
 
-cd "${src_dir}"
-build_dir=$(mktemp -p "${PWD}" -d _site-XXXXXX)
-mkdocs build --clean --site-dir "${build_dir}"
+if [ "${site_generation}" = "true" ]; then
+  cd "${src_dir}"
+  build_dir=$(mktemp -p "${PWD}" -d _site-XXXXXX)
+  mkdocs build --clean --site-dir "${build_dir}"  
+fi
+
+if [ "${site_generation}" = "false" ]; then
+  build_dir=$(mktemp -p "/tmp" -d _site-XXXXXX)
+  cp -a "${src_dir}"/. "${build_dir}"  
+fi
 
 if [ "${iam_role}" != "NONE" ]; then
   aws sts assume-role  \


### PR DESCRIPTION
When site_generation is specified as "false", the files in source directory
are hosted as it is